### PR TITLE
実機とデバイスで処理を分岐する

### DIFF
--- a/BadHouseApp/Controller/VideoPost/PostViewController.swift
+++ b/BadHouseApp/Controller/VideoPost/PostViewController.swift
@@ -33,6 +33,9 @@ class PostViewController: UIViewController {
       }
     
     @objc private func handle(sender:UIButton) {
+        #if targetEnvironment(simulator)
+            // do nothing
+        #else
         if sender == singleButton {
             print("single")
             let vc = storyboard?.instantiateViewController(withIdentifier: "CameraVC") as! CameraViewController
@@ -49,5 +52,6 @@ class PostViewController: UIViewController {
             vc.keyWord = "ミックス"
             navigationController?.pushViewController(vc, animated: true)
         }
+        #endif
     }
 }


### PR DESCRIPTION
シミュレーターか実機かで処理を分ける方法を追加しました！

#から始まる書き方はコンパイラディレクティブというものでビルド時の条件とかをコンパイラに指示できる書き方です。

この場合、実機の時しかボタンのハンドリングがされなくなります＝シミュレーターで間違ってボタン押したちゃっても落ちなくなる