### PR TITLE
Create standard color set

### DIFF
--- a/BadHouseApp/Views/Stroyboard/Assets.xcassets/Color/Contents.json
+++ b/BadHouseApp/Views/Stroyboard/Assets.xcassets/Color/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BadHouseApp/Views/Stroyboard/Assets.xcassets/Color/StandardColor.colorset/Contents.json
+++ b/BadHouseApp/Views/Stroyboard/Assets.xcassets/Color/StandardColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "247",
+          "green" : "237",
+          "red" : "136"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
AssetsはColor Setも作ることができます。
また、フォルダを作って分類することもできます。

今回は例として下記の定義にあたるColor Setを作ってみました。

> static let StandardColor:UIColor = .rgb(red: 136, green: 237, blue: 247, alpha: 1.0)

![スクリーンショット_2021-10-14_0_52_53](https://user-images.githubusercontent.com/2178775/137170105-1c3ec4d2-f0dc-45e7-8998-39a0f4ab1222.png)

更に使いやすくするために下記の記事のようにextensionを作ると

> backgroundColor = UIColor.standardColor

のように実際のUIColorのように設定することもできるようになります。

参考
https://qiita.com/shira-shun/items/281e583f1aa0fc446b87

このあたりをうまく使って色の設定を管理してみてください！